### PR TITLE
Add chipflow-digital-ip documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,8 @@ from tools import copy_docs
 repos = [
     ('amaranth-lang/amaranth', 'tags/v0.5.4'),
     ('chipflow/amaranth-soc', 'origin/reference-docs-chipflow'),
-    ('chipflow/chipflow-lib', 'origin/main')
+    ('chipflow/chipflow-lib', 'origin/main'),
+    ('chipflow/chipflow-digital-ip', 'origin/main')
 ]
 
 # copy in the doc sources from our repos

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Contents
 
    chipflow-lib/getting-started
    chipflow-lib/index
+   Digital IP Library <chipflow-digital-ip/index>
    Amaranth Language and Toolchain <amaranth/index>
    Amaranth System-on-a-Chip toolkit <amaranth-soc/index>
    support


### PR DESCRIPTION
## Summary
- Add chipflow-digital-ip repo to documentation build
- Add "Digital IP Library" entry to main navigation

## Dependencies
- Depends on https://github.com/ChipFlow/chipflow-digital-ip/pull/41 for the title fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)